### PR TITLE
changed the event name

### DIFF
--- a/src/etc/frontend/events.xml
+++ b/src/etc/frontend/events.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
-    <event name="controller_action_predispatch">
+    <event name="controller_action_predispatch_catalogsearch_result_index">
         <observer name="Actiview_CatalogSearchSpamFilter::controller_action_predispatch" instance="Actiview\CatalogSearchSpamFilter\Observer\ControllerActionPredispatchObserver" />
     </event>
 </config>


### PR DESCRIPTION
The `controller_action_predispatch` event is triggered every time a page is called. A better option is to use the `controller_action_predispatch_catalogsearch_result_index` event. This event is triggered just before a search is performed, thus avoiding unnecessary event calls on every page.

Ref. https://magento.stackexchange.com/a/122686/111038